### PR TITLE
Ot90 716

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "0.24.0",
     "bootstrap": "5.1.3",
     "dotenv": "10.0.0",
+    "eslint-config-react-app": "^6.0.0",
     "formik": "^2.2.9",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "0.24.0",
-    "bootstrap": "^5.1.3",
+    "bootstrap": "5.1.3",
     "dotenv": "10.0.0",
     "formik": "^2.2.9",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-aws-s3": "1.5.0",
+    "react-bootstrap": "^2.0.2",
     "react-dom": "16.13.1",
     "react-loader-spinner": "4.0.0",
     "react-redux": "7.1.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,10 +44,10 @@ function App() {
       </div>
       <Loader visible={visible} />
       <header className="App-header">
-        <ButtonComponent title="Test Button!!!!!!!!!!!!!" isLoading={false}  disabled={false} onClick={() => openAlert()} />
+        <ButtonComponent title="Test Button!!!!!!!!!!!!!" isLoading={false} disabled={false} onClick={() => openAlert()} />
       </header>
 
-      <CategoryForm />
+      <CategoryForm name="asd" description="description1" id={1} />
     </div>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Backoffice from './Component/Backoffice'
 import './App.css'
 import './static/styles/Alert.css'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import CategoryForm from './Component/CategoryForm';
 
 const initialAlertState = { status: false, title: '', content: '' }
 
@@ -43,8 +44,10 @@ function App() {
       </div>
       <Loader visible={visible} />
       <header className="App-header">
-        <ButtonComponent title="Test Button" onClick={() => openAlert()} />
+        <ButtonComponent title="Test Button!!!!!!!!!!!!!" isLoading={false}  disabled={false} onClick={() => openAlert()} />
       </header>
+
+      <CategoryForm />
     </div>
   )
 }

--- a/src/Component/CategoryForm.jsx
+++ b/src/Component/CategoryForm.jsx
@@ -27,7 +27,6 @@ const CategoryForm = (body) => {
         setVisible(false)
         setShow(true)
       } else {
-        // await axios.patch(`http://localhost:3001/categories/${id}`, form)
         await sendRequest('put',`/categories/${id}`, form)
         setVisible(false)
         setVariant('success')
@@ -36,7 +35,6 @@ const CategoryForm = (body) => {
       }
     } catch (error) {
       setVariant('danger')
-      console.log(error)
       setTitle(`No se pudo crear la categoría`)
       setShow(true)
       setVisible(false)

--- a/src/Component/CategoryForm.jsx
+++ b/src/Component/CategoryForm.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
 import { Container, Form, Button } from 'react-bootstrap'
-import axios from 'axios'
 import Loader from './Loader'
 import AlertComponent from './Alert'
 import sendRequest from '../httpClient'
+
 const CategoryForm = (body) => {
   const { name = '', description = '', id } = body
 
@@ -21,13 +21,13 @@ const CategoryForm = (body) => {
     try {
       setVisible(true)
       if (name === '' && description === '') {
-        await sendRequest('post','/categories', form)
+        await sendRequest('post', '/categories', form)
         setVariant('success')
         setTitle(`${form.name} Creada!`)
         setVisible(false)
         setShow(true)
       } else {
-        await sendRequest('put',`/categories/${id}`, form)
+        await sendRequest('put', `/categories/${id}`, form)
         setVisible(false)
         setVariant('success')
         setTitle(`${form.name} updated!`)
@@ -35,7 +35,7 @@ const CategoryForm = (body) => {
       }
     } catch (error) {
       setVariant('danger')
-      setTitle(`No se pudo crear la categoría`)
+      setTitle('No se pudo crear la categoría')
       setShow(true)
       setVisible(false)
     }

--- a/src/Component/CategoryForm.jsx
+++ b/src/Component/CategoryForm.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { Container, Form, Button } from 'react-bootstrap'
+import axios from 'axios'
+import Loader from './Loader'
+import AlertComponent from './Alert'
+import sendRequest from '../httpClient'
+const CategoryForm = (body) => {
+  const { name = '', description = '', id } = body
+
+  const [form, setForm] = useState({ name, description })
+  const [visible, setVisible] = useState(false)
+  const [show, setShow] = useState(false)
+  const [variant, setVariant] = useState('success')
+  const [title, setTitle] = useState('Success!')
+  const handleChange = (eventName, eventValue) => {
+    setForm((prev) => ({ ...prev, [eventName]: eventValue }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      setVisible(true)
+      if (name === '' && description === '') {
+        await sendRequest('post','/categories', form)
+        setVariant('success')
+        setTitle(`${form.name} Creada!`)
+        setVisible(false)
+        setShow(true)
+      } else {
+        // await axios.patch(`http://localhost:3001/categories/${id}`, form)
+        await sendRequest('put',`/categories/${id}`, form)
+        setVisible(false)
+        setVariant('success')
+        setTitle(`${form.name} updated!`)
+        setShow(true)
+      }
+    } catch (error) {
+      setVariant('danger')
+      console.log(error)
+      setTitle(`No se pudo crear la categoría`)
+      setShow(true)
+      setVisible(false)
+    }
+  }
+
+  return (
+    <>
+      <AlertComponent show={show} variant={variant} title={title} action={() => setShow(false)} />
+      <Loader visible={visible} />
+      <Container className="mt-5">
+        <Form>
+          <Form.Group className="mb-3" controlId="Nombre">
+            <Form.Label>Nombre</Form.Label>
+            <Form.Control name="name" value={form.name} onChange={(event) => handleChange(event.target.name, event.target.value)} />
+          </Form.Group>
+          <Form.Group className="mb-3" controlId="Descripcion">
+            <Form.Label>Descripción</Form.Label>
+            <Form.Control as="textarea" rows={3} value={form.description} name="description" onChange={(event) => handleChange(event.target.name, event.target.value)} />
+          </Form.Group>
+        </Form>
+
+        {form.name === '' || form.description === ''
+          ? (
+            <Button variant="success" onClick={handleSubmit} disabled>
+              Save Changes
+            </Button>
+          )
+          : (
+            <Button variant="success" onClick={handleSubmit}>
+              Save Changes
+            </Button>
+          )}
+
+      </Container>
+    </>
+  )
+}
+
+export default CategoryForm

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -11,9 +11,9 @@ export default async function sendRequest(method, relativeUrl, data) {
     ? process.env.REACT_APP_BASE_URL_PRODUCTION
     : process.env.REACT_APP_BASE_URL_LOCAL
   const url = baseUrl + relativeUrl
-    const response = await axios({
+  const response = await axios({
     method, url, data, headers: { Authorization: token },
   })
-    .catch((error) =>{throw error.message})
+    .catch((error) => { throw error.message })
   return response
 }

--- a/src/httpClient.js
+++ b/src/httpClient.js
@@ -6,14 +6,14 @@ dotenv.config()
 export default async function sendRequest(method, relativeUrl, data) {
   let token = null
   const userData = JSON.parse(localStorage.getItem('user-data')) || null
-  if (userData === !null) token = `Bearer  ${userData.token}`
+  if (userData !== null) token = `Bearer ${userData.authorization}`
   const baseUrl = process.env.REACT_APP_NODE_ENV === 'production'
     ? process.env.REACT_APP_BASE_URL_PRODUCTION
     : process.env.REACT_APP_BASE_URL_LOCAL
   const url = baseUrl + relativeUrl
-  const response = await axios({
+    const response = await axios({
     method, url, data, headers: { Authorization: token },
   })
-    .catch((error) => error.response)
+    .catch((error) =>{throw error.message})
   return response
 }


### PR DESCRIPTION
COMO: Usuario administrador
QUIERO: Crear o editar una categoría existente
PARA: Mantener el contenido actualizado

Criterios de aceptación: El mismo contendrá los campos Nombre (en la base de datos es name) y Descripción (en la base de datos es description). El objetivo es crear un formulario reutilizable para las acciones de edición como de creación. Para esto, deberá poder comportarse de forma diferente según recibe un objeto o no.  En el caso de no recibir un objeto, significa que está realizando una acción de creación, por lo que deberá mostrar los campos vacíos y realizar una petición POST al endpoint de creación  (/categories). En el caso de recibir un objeto, completar el formulario con los campos del mismo y realizar una petición PATCH al endpoint de actualización (/categories/:id). Este formulario se mostrará en el backoffice tanto para la creación como edición

![image](https://user-images.githubusercontent.com/73470251/140804704-2225daef-141e-4156-b251-cac3391d1f39.png)
![image](https://user-images.githubusercontent.com/73470251/140804720-6ea7042c-9175-4dba-abf9-c28f86b02b57.png)
